### PR TITLE
Add Header test and testUtils with renderWithProviders & wrapWithRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "vitest run",
+    "test:dev": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@fontsource/libre-baskerville": "^5.0.1",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Allow: /

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
+import Header from "./Header";
+
+describe("Given a Header component", () => {
+  describe("When it is rendered ", () => {
+    test("Then it should show the Bretaro logo with the alternative text 'bretaro logo'", () => {
+      renderWithProviders(wrapWithRouter(<Header />));
+      const expectedAlternativeText = "bretaro logo";
+
+      const bretaroLogo = screen.getByAltText(expectedAlternativeText);
+
+      expect(bretaroLogo).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,8 +4,8 @@ const Header = (): React.ReactElement => {
   return (
     <HeaderStyled>
       <img
-        src="/public/images/text-logo.svg"
-        alt="brearo logo"
+        src="/images/text-logo.svg"
+        alt="bretaro logo"
         width={200}
         height={30}
       />

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -1,0 +1,40 @@
+import { PreloadedState } from "@reduxjs/toolkit";
+import { RootState, setupStore, store } from "../store";
+import { PropsWithChildren } from "react";
+import { render } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import theme from "../styles/theme";
+import GlobalStyle from "../styles/GlobalStyle/GlobalStyle";
+import { Provider } from "react-redux";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+export const renderWithProviders = (
+  ui: React.ReactElement,
+  preloadedState?: PreloadedState<RootState>
+) => {
+  const testStore = preloadedState ? setupStore(preloadedState) : store;
+
+  const Wrapper = ({ children }: PropsWithChildren): React.ReactElement => {
+    return (
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Provider store={testStore}>{children}</Provider>
+      </ThemeProvider>
+    );
+  };
+
+  render(ui, { wrapper: Wrapper });
+};
+
+export const wrapWithRouter = (ui: React.ReactElement) => {
+  const routes = [
+    {
+      path: "/",
+      element: ui,
+    },
+  ];
+
+  const router = createMemoryRouter(routes);
+
+  return <RouterProvider router={router} />;
+};


### PR DESCRIPTION
Creado test para componente Header (renderiza un logo con un texto alternativo).

Creados test utils para la renderización y el enrutado