### PR TITLE
Bugfix/ellipsis

### DIFF
--- a/src/components/BookCard/BookCard.test.tsx
+++ b/src/components/BookCard/BookCard.test.tsx
@@ -12,7 +12,7 @@ describe("Given a BookCard component", () => {
     test("Then it should show the information that its author is 'Carlos Montero'", () => {
       const expectedAuthor = booksMocks[0].author;
 
-      const bookAuthor = screen.getByRole("heading", { name: expectedAuthor });
+      const bookAuthor = screen.getByText(expectedAuthor);
 
       expect(bookAuthor).toBeInTheDocument;
     });

--- a/src/components/BookCard/BookCard.tsx
+++ b/src/components/BookCard/BookCard.tsx
@@ -17,7 +17,7 @@ const BookCard = ({ bookProps }: BookCardProps): React.ReactElement => {
       />
       <div className="info-book">
         <h2 className="info-book__title">{bookProps.title}</h2>
-        <h3 className="info-book__author">{bookProps.author}</h3>
+        <span className="info-book__author">{bookProps.author}</span>
       </div>
     </BookCardStyled>
   );

--- a/src/components/BookCard/BookCardStyled.ts
+++ b/src/components/BookCard/BookCardStyled.ts
@@ -22,9 +22,6 @@ const BookCardStyled = styled.article`
     font-size: ${(props) => props.theme.fontSize.small};
 
     &__title {
-      max-width: 13ch;
-      white-space: nowrap;
-      text-overflow: ellipsis;
       overflow: hidden;
       font-weight: bold;
     }


### PR DESCRIPTION
Eliminada la propiedad ellipsis en favor de títulos de las cards de dos líneas.

Cambiada la etiqueda h3 de los autores de las cards --> span (mejor sentido semántico)

Arreglado caso de uso en test BookCard, roto tras el cambio de h3--> span 