### PR TITLE
Add NotFoundPage.test with its corresponding use cases

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,16 +3,26 @@ interface ButtonProps {
   text?: string;
   classname: string;
   actionOnClick?: () => void;
+  title?: string;
+  ariaLabel?: string;
 }
 
 const Button = ({
   image,
   text,
   classname,
+  ariaLabel,
+  title,
   actionOnClick,
 }: ButtonProps): React.ReactElement => {
   return (
-    <button type="button" className={classname} onClick={actionOnClick}>
+    <button
+      type="button"
+      className={classname}
+      onClick={actionOnClick}
+      aria-label={ariaLabel}
+      title={title}
+    >
       {text}
       {image}
     </button>

--- a/src/pages/BookListPage/BookListPage.test.tsx
+++ b/src/pages/BookListPage/BookListPage.test.tsx
@@ -1,7 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
-
 import userEvent from "@testing-library/user-event";
-
 import { LazyBookListPage } from "../../routers/lazyComponents";
 import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
 import modalData from "../../data/modalData";
@@ -33,7 +31,7 @@ describe("Given a BookListPage page", () => {
       });
     });
 
-    describe("When renders an feedback Modal and a user clicks on the close button", () => {
+    describe("When renders a feedback Modal and a user clicks on the close button", () => {
       test("Then it should disappear", async () => {
         const expectedAlternativeText = "modal icon";
 

--- a/src/pages/NotFoundPage/NotFoundPage.test.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.test.tsx
@@ -1,0 +1,36 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LazyNotFoundPage } from "../../routers/lazyComponents";
+import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
+import NotFoundPage from "./NotFoundPage";
+
+describe("Given a NotFoundPage", () => {
+  describe("When it is rendered", () => {
+    test("Then it should show a title with the text 'Page not found'", async () => {
+      const expectedTitle = "Page not found";
+
+      renderWithProviders(wrapWithRouter(<LazyNotFoundPage />));
+
+      const title = await waitFor(() =>
+        screen.getByRole("heading", { name: expectedTitle })
+      );
+
+      expect(title).toBeInTheDocument();
+    });
+  });
+
+  describe("When the user clicks on the 'Back home' button", () => {
+    test("Then it should disappear", async () => {
+      const expectedTitle = "Page not found";
+      const expectedLabeltext = "back home";
+
+      renderWithProviders(wrapWithRouter(<NotFoundPage />));
+
+      const title = screen.getByText(expectedTitle);
+      const button = screen.getByLabelText(expectedLabeltext);
+      await userEvent.click(button);
+
+      expect(title).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -27,6 +27,8 @@ const NotFoundPage = (): React.ReactElement => {
             classname="button"
             text="Back home"
             actionOnClick={handleOnClick}
+            title="back home"
+            ariaLabel="back home"
           />
         </NotFoundPageStyled>
       </ContainerStyled>


### PR DESCRIPTION
Creado el archivo test para NotFoundPage que contempla los siguientes casos de uso:
- Renderización de la LazyNotFoundPage --> se busca un título
- Comportamiento esperado al clickar botón 'Back home' --> que desaparece el título