### PR TITLE
Fix router paths and rederization of NotFoundPage

### DIFF
--- a/src/components/Loader/Loader.test.tsx
+++ b/src/components/Loader/Loader.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
+import { renderWithProviders } from "../../utils/testUtils";
 import Loader from "./Loader";
 
 describe("Given a Loader component", () => {
@@ -7,7 +7,7 @@ describe("Given a Loader component", () => {
     test("Then it should show an spinner animation with the name 'loader animation'", () => {
       const expectedName = "loader animation";
 
-      renderWithProviders(wrapWithRouter(<Loader />));
+      renderWithProviders(<Loader />);
 
       const loader = screen.getByLabelText(expectedName);
 

--- a/src/hooks/useBooks/useBooks.ts
+++ b/src/hooks/useBooks/useBooks.ts
@@ -22,7 +22,7 @@ const useBooks = () => {
 
       dispatch(hideLoadingActionCreator());
       return books;
-    } catch (error) {
+    } catch {
       dispatch(hideLoadingActionCreator());
       dispatch(showModalActionCreator({ isError: true }));
       throw new Error("Can't get books");

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,8 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import Button from "../../components/Button/Button";
-import Header from "../../components/Header/Header";
-import Navbar from "../../components/Navbar/Navbar";
-import ContainerStyled from "../../components/shared/ContainerStyled";
 import NotFoundPageStyled from "./NotFoundPageStyled";
 import paths from "../../routers/paths/paths";
 
@@ -13,27 +10,21 @@ const NotFoundPage = (): React.ReactElement => {
     navigate(paths.home);
   };
   return (
-    <>
-      <ContainerStyled>
-        <Header />
-        <NotFoundPageStyled>
-          <h2 className="error">404</h2>
-          <span className="feedback">Glops!</span>
-          <h1 className="feedback">Page not found</h1>
-          <p className="message">
-            It is a good time to pick un a book and continue reading
-          </p>
-          <Button
-            classname="button"
-            text="Back home"
-            actionOnClick={handleOnClick}
-            title="back home"
-            ariaLabel="back home"
-          />
-        </NotFoundPageStyled>
-      </ContainerStyled>
-      <Navbar />
-    </>
+    <NotFoundPageStyled>
+      <span className="error">404</span>
+      <span className="feedback">Glops!</span>
+      <h1 className="feedback">Page not found</h1>
+      <p className="message">
+        It is a good time to pick up a book and continue reading
+      </p>
+      <Button
+        classname="button"
+        text="Back home"
+        actionOnClick={handleOnClick}
+        title="back home"
+        ariaLabel="back home"
+      />
+    </NotFoundPageStyled>
   );
 };
 

--- a/src/routers/appRouter.tsx
+++ b/src/routers/appRouter.tsx
@@ -1,4 +1,4 @@
-import { RouteObject, createBrowserRouter } from "react-router-dom";
+import { Navigate, RouteObject, createBrowserRouter } from "react-router-dom";
 import App from "../components/App/App";
 import { Suspense } from "react";
 import { LazyBookListPage, LazyNotFoundPage } from "./lazyComponents";
@@ -8,17 +8,25 @@ const routes: RouteObject[] = [
   {
     path: paths.app,
     element: <App />,
-    errorElement: (
-      <Suspense>
-        <LazyNotFoundPage />
-      </Suspense>
-    ),
+
     children: [
+      {
+        index: true,
+        element: <Navigate to={paths.home} replace />,
+      },
       {
         path: paths.home,
         element: (
           <Suspense>
             <LazyBookListPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: "/*",
+        element: (
+          <Suspense>
+            <LazyNotFoundPage />
           </Suspense>
         ),
       },


### PR DESCRIPTION
NotFoundPage:
- Cambiado el elemento h2 --> span


appRouter:
- Eliminada la propiedad errorElement para renderizar, de forma más correcta la LazyNotFoundPage cuando el path es desconocido
- Añadido el index para que el usuario sea redirigido a la lista de libros al entrar en la página

Tras estos cambios, la renderización de la NotFoundPage se realiza en el seno de Layout, por lo que ya no necesita contener el ContainerStyled, el Header ni la NavBar (evitamos así este código repetido)