### PR TITLE
Bugfix/book list loader

### DIFF
--- a/src/components/BooksList/BooksListStyled.ts
+++ b/src/components/BooksList/BooksListStyled.ts
@@ -4,6 +4,7 @@ const BookListStyled = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 40px;
+  margin-bottom: 100px;
 `;
 
 export default BookListStyled;

--- a/src/components/Loader/LoaderStyled.ts
+++ b/src/components/Loader/LoaderStyled.ts
@@ -8,6 +8,7 @@ const LoaderStyled = styled.div`
   justify-content: center;
   align-items: center;
   position: absolute;
+  z-index: 10;
 
   .loader {
     width: 77px;


### PR DESCRIPTION
Añadido un margin bottom a la lista de libros para que el scroll sea correcto (antes la última card quedaba parcialmente ocultada por la NavBar)

Añadido z-index para un correcto renderizado del Loader (antes se renderizaba por debajo de las cards)