### PR TITLE
Feature/delete item

### DIFF
--- a/src/components/BookCard/BookCard.test.tsx
+++ b/src/components/BookCard/BookCard.test.tsx
@@ -1,16 +1,16 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { booksMocks } from "../../mocks/booksMock";
-import { renderWithProviders } from "../../utils/testUtils";
+import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
 import BookCard from "./BookCard";
-
-beforeEach(() => {
-  renderWithProviders(<BookCard bookProps={booksMocks[0]} />);
-});
+import BookListPage from "../../pages/BookListPage/BookListPage";
 
 describe("Given a BookCard component", () => {
   describe("When it receives the book 'El desorden que dejas'", () => {
     test("Then it should show the information that its author is 'Carlos Montero'", () => {
       const expectedAuthor = booksMocks[0].author;
+
+      renderWithProviders(<BookCard bookProps={booksMocks[0]} />);
 
       const bookAuthor = screen.getByText(expectedAuthor);
 
@@ -19,6 +19,7 @@ describe("Given a BookCard component", () => {
 
     test("Then it should show a front page image with the alternative text 'El desorden que dejas front page'", () => {
       const expectedAlternativeText = `${booksMocks[0].title} front page`;
+      renderWithProviders(<BookCard bookProps={booksMocks[0]} />);
 
       const frontPage = screen.getByAltText(expectedAlternativeText);
 
@@ -29,10 +30,28 @@ describe("Given a BookCard component", () => {
   describe("When it is rendered", () => {
     test("Then it should show a delete button with an icon with the alternative text 'delete icon'", () => {
       const expectedAlternativeText = "delete icon";
+      renderWithProviders(<BookCard bookProps={booksMocks[0]} />);
 
       const deleteButton = screen.getByAltText(expectedAlternativeText);
 
       expect(deleteButton).toBeInTheDocument();
+    });
+  });
+
+  describe("When an user clicks on the card delete button", () => {
+    test("Then this card should disappear", async () => {
+      const expectedCardTitle = "El desorden que dejas";
+
+      renderWithProviders(wrapWithRouter(<BookListPage />), {
+        books: { booksData: booksMocks },
+      });
+
+      const title = screen.getByRole("heading", { name: expectedCardTitle });
+      const button = screen.getAllByRole("button", { name: "delete" });
+
+      await userEvent.click(button[0]);
+
+      expect(title).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/BookCard/BookCard.tsx
+++ b/src/components/BookCard/BookCard.tsx
@@ -1,3 +1,6 @@
+import useBooks from "../../hooks/useBooks/useBooks";
+import { useAppDispatch } from "../../store";
+import { deleteBooksActionCreator } from "../../store/books/booksSlice";
 import { BookStructure } from "../../types";
 import Button from "../Button/Button";
 import BookCardStyled from "./BookCardStyled";
@@ -8,6 +11,14 @@ interface BookCardProps {
 }
 
 const BookCard = ({ bookProps, isLazy }: BookCardProps): React.ReactElement => {
+  const { deleteBooks } = useBooks();
+  const dispatch = useAppDispatch();
+
+  const handleOnClick = () => {
+    deleteBooks(bookProps.id);
+    dispatch(deleteBooksActionCreator(bookProps.id));
+  };
+
   return (
     <BookCardStyled>
       <img
@@ -33,6 +44,7 @@ const BookCard = ({ bookProps, isLazy }: BookCardProps): React.ReactElement => {
             height={24}
           />
         }
+        actionOnClick={handleOnClick}
       />
     </BookCardStyled>
   );

--- a/src/components/BookCard/BookCard.tsx
+++ b/src/components/BookCard/BookCard.tsx
@@ -35,7 +35,8 @@ const BookCard = ({ bookProps, isLazy }: BookCardProps): React.ReactElement => {
       </div>
       <Button
         classname="card__button"
-        aria-label="delete"
+        ariaLabel="delete"
+        title="delete"
         image={
           <img
             src="/images/delete-icon.svg"

--- a/src/components/Layout/Layout.test.tsx
+++ b/src/components/Layout/Layout.test.tsx
@@ -77,7 +77,7 @@ describe("Given a Layout component", () => {
     });
   });
 
-  describe("When renders a feedback Modal and a user clicks on the close button", () => {
+  describe("When renders a feedback Modal and an user clicks on the close button", () => {
     test("Then it should disappear", async () => {
       const expectedAlternativeText = "modal icon";
 

--- a/src/hooks/useBooks/useBooks.test.ts
+++ b/src/hooks/useBooks/useBooks.test.ts
@@ -2,8 +2,10 @@ import { renderHook } from "@testing-library/react";
 import { booksMocks } from "../../mocks/booksMock";
 import useBooks from "./useBooks";
 import { server } from "../../mocks/server";
-import { errorHandlers } from "../../mocks/handlers";
+import { errorHandlers, handlers } from "../../mocks/handlers";
 import { wrapper } from "../../utils/testUtils";
+import modalData from "../../components/Modal/modalData";
+import { store } from "../../store";
 
 describe("Given a useBooks function", () => {
   describe("When it calls the getBooks function", () => {
@@ -32,6 +34,48 @@ describe("Given a useBooks function", () => {
       } = renderHook(() => useBooks(), { wrapper: wrapper });
 
       expect(getBooks()).rejects.toThrowError();
+    });
+  });
+
+  describe("When it calls the deleteBooks function with a correct id", () => {
+    test("Then the feedback message 'You no longer have this book on your shelf' should be in the store", async () => {
+      server.resetHandlers(...handlers);
+
+      const bookId = booksMocks[0].id;
+      const message = modalData.message.okDeleted;
+
+      const {
+        result: {
+          current: { deleteBooks },
+        },
+      } = renderHook(() => useBooks(), { wrapper: wrapper });
+
+      await deleteBooks(bookId);
+
+      const expectedMessage = store.getState().ui.modalState.message;
+
+      expect(message).toBe(expectedMessage);
+    });
+
+    describe("When it calls the deleteBooks function with a incorrect id", () => {
+      test("Then the feedback message 'Couldn't remove this book from your shelf'", async () => {
+        server.resetHandlers(...errorHandlers);
+
+        const errorId = "sdkfnsdfl";
+        const message = modalData.message.errorRemove;
+
+        const {
+          result: {
+            current: { deleteBooks },
+          },
+        } = renderHook(() => useBooks(), { wrapper: wrapper });
+
+        await deleteBooks(errorId);
+
+        const expectedMessage = store.getState().ui.modalState.message;
+
+        expect(message).toBe(expectedMessage);
+      });
     });
   });
 });

--- a/src/hooks/useBooks/useBooks.ts
+++ b/src/hooks/useBooks/useBooks.ts
@@ -36,7 +36,33 @@ const useBooks = () => {
     }
   }, [dispatch]);
 
-  return { getBooks };
+  const deleteBooks = async (id: string): Promise<void> => {
+    try {
+      dispatch(showLoadingActionCreator());
+
+      await axios.delete<void>(`${apiUrl}/books/delete/${id}`);
+
+      dispatch(hideLoadingActionCreator());
+
+      dispatch(
+        showModalActionCreator({
+          isError: false,
+          isVisible: true,
+          message: modalData.message.okDeleted,
+        })
+      );
+    } catch {
+      dispatch(
+        showModalActionCreator({
+          isError: true,
+          isVisible: true,
+          message: modalData.message.errorRemove,
+        })
+      );
+    }
+  };
+
+  return { getBooks, deleteBooks };
 };
 
 export default useBooks;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,15 +1,30 @@
 import { rest } from "msw";
 import { apiUrl } from "../hooks/useBooks/useBooks";
 import { booksMocks } from "./booksMock";
+import modalData from "../components/Modal/modalData";
 
 export const handlers = [
   rest.get(`${apiUrl}/books`, (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json(booksMocks));
+  }),
+
+  rest.delete(`${apiUrl}/books/delete/:id`, (_req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({ message: modalData.message.okDeleted })
+    );
   }),
 ];
 
 export const errorHandlers = [
   rest.get(`${apiUrl}/books`, (_req, res, ctx) => {
     return res(ctx.status(500), ctx.json({ errorMessage: "Can't get books" }));
+  }),
+
+  rest.delete(`${apiUrl}/books/delete/:id`, (_req, res, ctx) => {
+    return res(
+      ctx.status(404),
+      ctx.json({ mesage: modalData.message.errorRemove })
+    );
   }),
 ];


### PR DESCRIPTION
Añadida la función deleteBook en el hook de la api (useBook).

Gestionado el feedback al usuario:
 - Aparición de Loader mientras se realiza la petición
 - Aparición de modal favorable o desfavorable en función del resultado de la petición.
 -
Dispatcheada la función deleteBook en el componente BookCard, asociándola a un evento click.

Testeados los posibles casos de uso de la función deleteBook:
- aparición de elemento modal favorable en caso de operación exitosa
- aparición de elemento modal de error en caso de operación fallida

Añadido un nuevo caso de uso a la suit de test BookCard.test que ahora debe contemplar también la acción asociada al click, para así seguir cubriendo el coverage.