### PR TITLE
Fix src path in Modal image and Modal delete icon

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -27,7 +27,7 @@ const Modal = ({ isError, message }: ModalProps): React.ReactElement => {
           actionOnClick={handleOnClose}
           image={
             <img
-              src="/public/images/delete-icon.svg"
+              src="/images/delete-icon.svg"
               alt="close"
               width={24}
               height={24}
@@ -37,7 +37,7 @@ const Modal = ({ isError, message }: ModalProps): React.ReactElement => {
         <img
           className="icon"
           alt="modal icon"
-          src={`/public/images/${isError ? "bad.svg" : "ok.svg"}`}
+          src={`/images/${isError ? "bad.svg" : "ok.svg"}`}
           width={105}
           height={80}
         />


### PR DESCRIPTION
Arregladas las rutas absolutas del icono del Modal y del icono del botón de cierre del modal.

En producción no se puede referir al path /public, porque al buildear, la raiz para netlify ya es public. 