### PR TITLE
Feature/create books hook

### DIFF
--- a/src/hooks/useBooks/useBooks.test.ts
+++ b/src/hooks/useBooks/useBooks.test.ts
@@ -1,5 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import { booksMocks } from "../../mocks/booksMock";
+import {
+  addedBookMock,
+  booksMocks,
+  createdBookMock,
+} from "../../mocks/booksMock";
 import useBooks from "./useBooks";
 import { server } from "../../mocks/server";
 import { errorHandlers, handlers } from "../../mocks/handlers";
@@ -58,7 +62,7 @@ describe("Given a useBooks function", () => {
     });
 
     describe("When it calls the deleteBooks function with a incorrect id", () => {
-      test("Then the feedback message 'Couldn't remove this book from your shelf'", async () => {
+      test("Then it should show the feedback message 'Couldn't remove this book from your shelf'", async () => {
         server.resetHandlers(...errorHandlers);
 
         const errorId = "sdkfnsdfl";
@@ -76,6 +80,45 @@ describe("Given a useBooks function", () => {
 
         expect(message).toBe(expectedMessage);
       });
+    });
+  });
+
+  describe("When it calls the createBooks function with the data of the book 'La uruguaya'", () => {
+    test("Then it should return the book 'La uruguaya'", async () => {
+      server.resetHandlers(...handlers);
+
+      const expectedBook = addedBookMock;
+
+      const {
+        result: {
+          current: { createBook },
+        },
+      } = renderHook(() => useBooks(), { wrapper: wrapper });
+
+      const newBook = await createBook(createdBookMock);
+
+      expect(newBook).toStrictEqual(expectedBook);
+    });
+  });
+
+  describe("When it calls the createBooks function with a book with invalid data", () => {
+    test("Then it should show the feedback message 'Couldn't add this book on your shelf'", async () => {
+      server.resetHandlers(...errorHandlers);
+
+      createdBookMock.author = "";
+      const message = modalData.message.erorAdd;
+
+      const {
+        result: {
+          current: { createBook },
+        },
+      } = renderHook(() => useBooks(), { wrapper: wrapper });
+
+      await createBook(createdBookMock);
+
+      const expectedMessage = store.getState().ui.modalState.message;
+
+      expect(message).toBe(expectedMessage);
     });
   });
 });

--- a/src/hooks/useBooks/useBooks.ts
+++ b/src/hooks/useBooks/useBooks.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import axios from "axios";
-import { BookDataStructure } from "../../types";
+import { BookDataStructure, BookStructure } from "../../types";
 import {
   hideLoadingActionCreator,
   showModalActionCreator,
@@ -62,7 +62,33 @@ const useBooks = () => {
     }
   };
 
-  return { getBooks, deleteBooks };
+  const createBook = async (
+    bookData: BookStructure
+  ): Promise<BookDataStructure | undefined> => {
+    try {
+      dispatch(showLoadingActionCreator());
+      const {
+        data: { newBook },
+      } = await axios.post<{ newBook: BookDataStructure }>(
+        `${apiUrl}/add`,
+        bookData
+      );
+      dispatch(hideLoadingActionCreator());
+
+      return newBook;
+    } catch {
+      dispatch(hideLoadingActionCreator());
+      dispatch(
+        showModalActionCreator({
+          isError: true,
+          message: modalData.message.erorAdd,
+          isVisible: true,
+        })
+      );
+    }
+  };
+
+  return { getBooks, deleteBooks, createBook };
 };
 
 export default useBooks;

--- a/src/hooks/useBooks/useBooks.ts
+++ b/src/hooks/useBooks/useBooks.ts
@@ -70,7 +70,7 @@ const useBooks = () => {
       const {
         data: { newBook },
       } = await axios.post<{ newBook: BookDataStructure }>(
-        `${apiUrl}/add`,
+        `${apiUrl}/books/add`,
         bookData
       );
       dispatch(hideLoadingActionCreator());

--- a/src/mocks/booksMock.ts
+++ b/src/mocks/booksMock.ts
@@ -1,4 +1,4 @@
-import { BookDataStructure } from "../types";
+import { BookDataStructure, BookStructure } from "../types";
 
 export const booksMocks: BookDataStructure[] = [
   {
@@ -33,6 +33,19 @@ export const booksMocks: BookDataStructure[] = [
 
 export const addedBookMock: BookDataStructure = {
   id: "647fa740ee528da72718451f",
+  title: "La uruguaya",
+  author: "Pedro Mairal",
+  frontPage: "image_la_uruguaya.jpg",
+  publicationYear: "2016",
+  editorial: "Libros del Asteroide",
+  status: true,
+  rating: 4,
+  destination: "keep",
+  cosmos:
+    "Un escritor argentino se embarca en un viaje a Montevideo que lo llevará a cuestionarse su vida, su matrimonio y sus ambiciones literarias.",
+};
+
+export const createdBookMock: BookStructure = {
   title: "La uruguaya",
   author: "Pedro Mairal",
   frontPage: "image_la_uruguaya.jpg",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,6 @@
 import { rest } from "msw";
 import { apiUrl } from "../hooks/useBooks/useBooks";
-import { booksMocks } from "./booksMock";
+import { addedBookMock, booksMocks } from "./booksMock";
 import modalData from "../components/Modal/modalData";
 
 export const handlers = [
@@ -14,6 +14,10 @@ export const handlers = [
       ctx.json({ message: modalData.message.okDeleted })
     );
   }),
+
+  rest.post(`${apiUrl}/books/add`, (_req, res, ctx) => {
+    return res(ctx.status(201), ctx.json({ newBook: addedBookMock }));
+  }),
 ];
 
 export const errorHandlers = [
@@ -25,6 +29,13 @@ export const errorHandlers = [
     return res(
       ctx.status(404),
       ctx.json({ mesage: modalData.message.errorRemove })
+    );
+  }),
+
+  rest.post(`${apiUrl}/books/add`, (_req, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({ message: modalData.message.erorAdd })
     );
   }),
 ];

--- a/src/store/books/booksSlice.test.ts
+++ b/src/store/books/booksSlice.test.ts
@@ -55,7 +55,7 @@ describe("Given a deleteBooks reducer", () => {
   });
 });
 
-describe("Giveb a addBooks reducer", () => {
+describe("Given a addBooks reducer", () => {
   describe("When it receives a collection of books, and the action to add a new book", () => {
     test("Then it should return a collection of book with the new book titled 'La uruguaya'", () => {
       const currentBooksState: BooksState = {


### PR DESCRIPTION
Creada la función createBook y añadida a useBooks.
- Añadida la gestión de feedback a usuario que corresponde a esta función (enseñar el spiner mientras se realiza la petición a la api + enseñar modal de error con el mensaje que corresponde a este caso)

Testeados los casos de uso que corresponden a la función createBook
- Que cuando se crea un libro lo devuelve
- Que cuando sucede un error (libro inválido) aparece el modal correspondiente.

Creados los handlers necesarios para poder testear los casos de uso antes mencionados.