### PR TITLE
Feature/lazy book detail page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link rel="preconnect" crossorigin href="https://camino-losada-final-project-back-202304.onrender.com">
   <link rel="preconnect" crossorigin href="https://res.cloudinary.com">
   <meta name="description" content="Bretaro allows you to organize your books on a virtual self">
-  <link rel="shortcut icon" href="/public/favicon.svg" type="image/x-icon">
+  <link rel="shortcut icon" href="/favicon.svg" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bretaro</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <link rel="preconnect" crossorigin href="https://camino-losada-final-project-back-202304.onrender.com">
+  <link rel="preconnect" crossorigin href="https://res.cloudinary.com">
   <meta name="description" content="Bretaro allows you to organize your books on a virtual self">
   <link rel="shortcut icon" href="/public/favicon.svg" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/components/BookCard/BookCard.tsx
+++ b/src/components/BookCard/BookCard.tsx
@@ -21,8 +21,8 @@ const BookCard = ({ bookProps, isLazy }: BookCardProps): React.ReactElement => {
   };
 
   return (
-    <Link to={`/home/${bookProps.id}`}>
-      <BookCardStyled>
+    <BookCardStyled>
+      <Link to={`/home/${bookProps.id}`}>
         <img
           src={bookProps.frontPage}
           alt={`${bookProps.title} front page`}
@@ -31,26 +31,26 @@ const BookCard = ({ bookProps, isLazy }: BookCardProps): React.ReactElement => {
           height="120"
           loading={isLazy}
         />
-        <div className="info">
-          <h2 className="info__title">{bookProps.title}</h2>
-          <span className="info__author">{bookProps.author}</span>
-        </div>
-        <Button
-          classname="card__button"
-          ariaLabel="delete"
-          title="delete"
-          image={
-            <img
-              src="/images/delete-icon.svg"
-              alt="delete icon"
-              width={24}
-              height={24}
-            />
-          }
-          actionOnClick={handleOnClick}
-        />
-      </BookCardStyled>
-    </Link>
+      </Link>
+      <div className="info">
+        <h2 className="info__title">{bookProps.title}</h2>
+        <span className="info__author">{bookProps.author}</span>
+      </div>
+      <Button
+        classname="card__button"
+        ariaLabel="delete"
+        title="delete"
+        image={
+          <img
+            src="/images/delete-icon.svg"
+            alt="delete icon"
+            width={24}
+            height={24}
+          />
+        }
+        actionOnClick={handleOnClick}
+      />
+    </BookCardStyled>
   );
 };
 

--- a/src/routers/appRouter.tsx
+++ b/src/routers/appRouter.tsx
@@ -3,11 +3,11 @@ import App from "../components/App/App";
 import { Suspense } from "react";
 import {
   LazyAddBookPage,
+  LazyBookDetailPage,
   LazyBookListPage,
   LazyNotFoundPage,
 } from "./lazyComponents";
 import paths from "./paths/paths";
-import BookDetailPage from "../pages/BookDetailPage/BookDetailPage";
 
 const routes: RouteObject[] = [
   {
@@ -36,16 +36,20 @@ const routes: RouteObject[] = [
         ),
       },
       {
+        path: paths.detail,
+        element: (
+          <Suspense>
+            <LazyBookDetailPage />
+          </Suspense>
+        ),
+      },
+      {
         path: "/*",
         element: (
           <Suspense>
             <LazyNotFoundPage />
           </Suspense>
         ),
-      },
-      {
-        path: "/home/:id",
-        element: <BookDetailPage />,
       },
     ],
   },

--- a/src/routers/lazyComponents.tsx
+++ b/src/routers/lazyComponents.tsx
@@ -11,3 +11,7 @@ export const LazyNotFoundPage = lazy(
 export const LazyAddBookPage = lazy(
   () => import("../pages/AddBookPage/AddBookPage")
 );
+
+export const LazyBookDetailPage = lazy(
+  () => import("../pages/BookDetailPage/BookDetailPage")
+);

--- a/src/routers/paths/paths.ts
+++ b/src/routers/paths/paths.ts
@@ -4,6 +4,7 @@ const paths: PathsStructure = {
   app: "/",
   home: "/home",
   addBook: "/add",
+  detail: "/home/:id",
 };
 
 export default paths;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,4 +33,5 @@ export interface PathsStructure {
   app: string;
   home: string;
   addBook: string;
+  detail: string;
 }


### PR DESCRIPTION
Cambio en el Link de la card: al envolver toda la card se producía un error al querer eliminar dicha card --> eliminaba + navegaba a esa página ya existente.
Solución: hacer que el componente clickable de la card sea la imagen (en features posteriores se pensará si colocar un botón para viajar al detalle). 

Añadido el preconnect a cloudinary para mejorar métricas lighthouse

Hacer que la BookDetailPage sea Lazy

Se corrige la ruta del favicon (no debe incluir /public)