### PR TITLE
Feature/app test

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,6 @@ sonar.sourceEncoding=UTF-8
 
 sonar.test.inclusions=src/**/*.test.ts, src/**/*.test.tsx
 
-sonar.coverage.exclusions=**/types.ts, **/*.d.ts, src/styles/GlobalStyle, src/main.tsx, src/components/App, src/routers/appRouter.tsx, src/routers/lazyComponents.tsx
+sonar.coverage.exclusions=**/types.ts, **/*.d.ts, src/styles/GlobalStyle, src/main.tsx, src/routers/lazyComponents.tsx
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -4,7 +4,7 @@ import App from "./App";
 
 describe("Given an App component", () => {
   describe("When it is rendered", () => {
-    test("Then it should  show the Bretaro logo with the alternative text 'bretaro logo'", () => {
+    test("Then it should show the Bretaro logo with the alternative text 'bretaro logo'", () => {
       const expectedAlternativeText = "bretaro logo";
       renderWithProviders(wrapWithRouter(<App />));
 

--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
+import App from "./App";
+
+describe("Given an App component", () => {
+  describe("When it is rendered", () => {
+    test("Then it should  show the Bretaro logo with the alternative text 'bretaro logo'", () => {
+      const expectedAlternativeText = "bretaro logo";
+      renderWithProviders(wrapWithRouter(<App />));
+
+      const bretaroLogo = screen.getByAltText(expectedAlternativeText);
+
+      expect(bretaroLogo).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -13,7 +13,7 @@ const Navbar = (): React.ReactElement => {
             aria-label="home"
           >
             <img
-              src="./images/home-icon.svg"
+              src="/images/home-icon.svg"
               alt="home icon"
               width={48}
               height={48}
@@ -28,7 +28,7 @@ const Navbar = (): React.ReactElement => {
             aria-label="add book"
           >
             <img
-              src="./images/add-book-icon.svg"
+              src="/images/add-book-icon.svg"
               alt="add book icon"
               width={48}
               height={48}

--- a/src/pages/BookDetailPage/BookDetailPage.test.tsx
+++ b/src/pages/BookDetailPage/BookDetailPage.test.tsx
@@ -27,7 +27,7 @@ describe("Given a BookDetailPage", () => {
       });
 
       const text = screen.getByText(expectedText);
-      screen.debug();
+
       expect(text).toBeInTheDocument;
     });
   });

--- a/src/routers/appRouter.test.tsx
+++ b/src/routers/appRouter.test.tsx
@@ -1,0 +1,27 @@
+import { RouterProvider } from "react-router-dom";
+import { renderWithProviders } from "../utils/testUtils";
+import appRouter from "./appRouter";
+import { screen } from "@testing-library/react";
+
+describe("Given an appRouter", () => {
+  describe("When it redirects to the home page", () => {
+    test("Then it should render a header with the Bretaro logo", () => {
+      const expectedAlternativeText = "bretaro logo";
+      renderWithProviders(<RouterProvider router={appRouter} />);
+
+      const bretaroLogo = screen.getByAltText(expectedAlternativeText);
+
+      expect(bretaroLogo).toBeInTheDocument();
+    });
+
+    test("Then it should render a navbar with a link to navigate to create book page", () => {
+      const expectedName = "add book";
+
+      renderWithProviders(<RouterProvider router={appRouter} />);
+
+      const link = screen.getByRole("link", { name: expectedName });
+
+      expect(link).toBeInTheDocument();
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,8 +20,6 @@ export default defineConfig({
         "**/*.d.ts",
         "src/styles/GlobalStyle",
         "src/main.tsx",
-        "src/components/App",
-        "src/routers/appRouter.tsx",
         "src/routers/lazyComponents.tsx",
       ],
     },


### PR DESCRIPTION
Quitadas las eclusiones para App y appRouter y testear ambos componentes.

App:
- Que muestra el logo Bretaro cuando es renderizado

appRouter:
- Que muestra el logo Bretaro cuando es renderizado
- Que muestra una barra de navegación con un icono para navegar a la página crear libro

Arregalas las rutas de las imágenes de la NavBar